### PR TITLE
Fix route import path casing

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const mongoose = require('mongoose');
-const stripeRoutes = require('./routes/stripe');
+const stripeRoutes = require('./Routes/stripe');
 
 //Stripe webhook setup//
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);


### PR DESCRIPTION
## Summary
- fix stripe routes import path to match directory casing

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6899fb46b5c88322a9ed5a79f5468703